### PR TITLE
Add support for extension urn:ietf:params:xml:ns:neulevel-1.0

### DIFF
--- a/check.go
+++ b/check.go
@@ -52,7 +52,9 @@ func (c *Conn) encodeDomainCheck(domains []string, launchPhase string) error {
 	}
 
 	supportsLaunch := greeting.SupportsExtension(ExtLaunch) && launchPhase != ""
-	hasExtension := feeURN != "" || supportsLaunch
+	supportsNeulevel := greeting.SupportsExtension(ExtNeulevel) || greeting.SupportsExtension(ExtNeulevel10)
+
+	hasExtension := feeURN != "" || supportsLaunch || supportsNeulevel
 
 	if hasExtension {
 		c.buf.WriteString(`<extension>`)
@@ -62,6 +64,12 @@ func (c *Conn) encodeDomainCheck(domains []string, launchPhase string) error {
 		c.buf.WriteString(`<launch:check xmlns:launch="` + ExtLaunch + `" type="avail">`)
 		c.buf.WriteString(`<launch:phase>` + launchPhase + `</launch:phase>`)
 		c.buf.WriteString(`</launch:check>`)
+	}
+
+	if supportsNeulevel {
+		c.buf.WriteString(`<neulevel:extension xmlns:neulevel="` + ExtNeulevel10 + `">`)
+		c.buf.WriteString(`<neulevel:unspec>FeeCheck=Y</neulevel:unspec>`)
+		c.buf.WriteString(`</neulevel:extension>`)
 	}
 
 	if len(feeURN) > 0 {
@@ -285,6 +293,26 @@ func init() {
 		if c.AttrBool("", "premium") {
 			charge.Category = "premium"
 		}
+		return nil
+	})
+
+	// Scan neulevel-1.0 extension
+	path = "epp > response > extension > " + ExtNeulevel10 + " extension > unspec"
+	scanResponse.MustHandleCharData(path, func(c *xx.Context) error {
+		dcd := &c.Value.(*response_).DomainCheckResponse
+		check := &dcd.Checks[len(dcd.Checks)-1]
+		charge := DomainCharge{Domain: check.Domain}
+		data := string(c.CharData)
+		pairs := strings.Split(data, " ")
+		for _, pair := range pairs {
+			parts := strings.SplitN(pair, "=", 2)
+			if parts[0] == "TierName" {
+				charge.Category = parts[1]
+				break
+			}
+		}
+		dcd.Charges = append(dcd.Charges, charge)
+
 		return nil
 	})
 }

--- a/check_test.go
+++ b/check_test.go
@@ -35,13 +35,25 @@ func TestConnCheck(t *testing.T) {
 }
 
 func TestEncodeDomainCheck(t *testing.T) {
-	var buf bytes.Buffer
-	err := encodeDomainCheck(&buf, []string{"hello.com", "foo.domains", "xn--ninja.net"}, Greeting{})
+	con := &Conn{}
+	err := con.encodeDomainCheck([]string{"hello.com", "foo.domains", "xn--ninja.net"}, "")
 	st.Expect(t, err, nil)
-	st.Expect(t, buf.String(), `<?xml version="1.0" encoding="UTF-8"?>
+	st.Expect(t, con.buf.String(), `<?xml version="1.0" encoding="UTF-8"?>
 <epp xmlns="urn:ietf:params:xml:ns:epp-1.0"><command><check><domain:check xmlns:domain="urn:ietf:params:xml:ns:domain-1.0"><domain:name>hello.com</domain:name><domain:name>foo.domains</domain:name><domain:name>xn--ninja.net</domain:name></domain:check></check></command></epp>`)
 	var v struct{}
-	err = xml.Unmarshal(buf.Bytes(), &v)
+	err = xml.Unmarshal(con.buf.Bytes(), &v)
+	st.Expect(t, err, nil)
+}
+
+func TestEncodeDomainCheckLaunchPhase(t *testing.T) {
+	con := &Conn{}
+	con.Greeting.Extensions = []string{ExtLaunch}
+	err := con.encodeDomainCheck([]string{"hello.com", "foo.domains", "xn--ninja.net"}, "claims")
+	st.Expect(t, err, nil)
+	st.Expect(t, con.buf.String(), `<?xml version="1.0" encoding="UTF-8"?>
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0"><command><check><domain:check xmlns:domain="urn:ietf:params:xml:ns:domain-1.0"><domain:name>hello.com</domain:name><domain:name>foo.domains</domain:name><domain:name>xn--ninja.net</domain:name></domain:check></check><extension><launch:check xmlns:launch="urn:ietf:params:xml:ns:launch-1.0" type="avail"><launch:phase>claims</launch:phase></launch:check></extension></command></epp>`)
+	var v struct{}
+	err = xml.Unmarshal(con.buf.Bytes(), &v)
 	st.Expect(t, err, nil)
 }
 
@@ -331,10 +343,10 @@ func TestScanCheckDomainResponsePriceExtension(t *testing.T) {
 }
 
 func BenchmarkEncodeDomainCheck(b *testing.B) {
-	var buf bytes.Buffer
+	con := &Conn{}
 	domains := []string{"hello.com"}
 	for i := 0; i < b.N; i++ {
-		encodeDomainCheck(&buf, domains, Greeting{})
+		con.encodeDomainCheck(domains, "")
 	}
 }
 

--- a/check_test.go
+++ b/check_test.go
@@ -304,6 +304,48 @@ func TestScanCheckDomainResponseWithPremiumAttribute(t *testing.T) {
 	st.Expect(t, dcr.Charges[0].CategoryName, "Registration Fee")
 }
 
+func TestScanCheckDomainResponseNeulevelExtension(t *testing.T) {
+	x := `<?xml version="1.0" encoding="utf-8"?>
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+	<response>
+		<result code="1000">
+			<msg>Command completed successfully</msg>
+		</result>
+		<resData>
+			<domain:chkData xmlns="urn:ietf:params:xml:ns:domain-1.0" xmlns:domain="urn:ietf:params:xml:ns:domain-1.0" xsi:schemaLocation="urn:ietf:params:xml:ns:domain-1.0 domain-1.0.xsd">
+				<domain:cd>
+					<domain:name avail="1">420.earth</domain:name>
+				</domain:cd>
+			</domain:chkData>
+		</resData>
+		<extension>
+			<neulevel:extension xmlns="urn:ietf:params:xml:ns:neulevel-1.0" xmlns:neulevel="urn:ietf:params:xml:ns:neulevel-1.0" xsi:schemaLocation="urn:ietf:params:xml:ns:neulevel-1.0 neulevel-1.0.xsd">
+				<neulevel:unspec>TierName=EARTH_Tier3 AnnualTierPrice=120.00</neulevel:unspec>
+			</neulevel:extension>
+		</extension>
+		<trID>
+			<clTRID>0000000000000002</clTRID>
+			<svTRID>83fa5767-5624-4be5-9e54-0b3a52f9de5b:1</svTRID>
+		</trID>
+	</response>
+</epp>`
+
+	var res response_
+	dcr := &res.DomainCheckResponse
+
+	d := decoder(x)
+	err := IgnoreEOF(scanResponse.Scan(d, &res))
+	st.Expect(t, err, nil)
+	st.Expect(t, len(dcr.Checks), 1)
+	st.Expect(t, dcr.Checks[0].Domain, "420.earth")
+	st.Expect(t, dcr.Checks[0].Available, true)
+	st.Expect(t, dcr.Checks[0].Reason, "")
+	st.Expect(t, len(dcr.Charges), 1)
+	st.Expect(t, dcr.Charges[0].Domain, "420.earth")
+	st.Expect(t, dcr.Charges[0].Category, "EARTH_Tier3")
+	st.Expect(t, dcr.Charges[0].CategoryName, "")
+}
+
 func TestScanCheckDomainResponsePriceExtension(t *testing.T) {
 	x := `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <epp xmlns="urn:ietf:params:xml:ns:epp-1.0">

--- a/greeting.go
+++ b/greeting.go
@@ -50,19 +50,21 @@ func (g *Greeting) SupportsExtension(uri string) bool {
 }
 
 const (
-	ObjDomain  = "urn:ietf:params:xml:ns:domain-1.0"
-	ObjHost    = "urn:ietf:params:xml:ns:host-1.0"
-	ObjContact = "urn:ietf:params:xml:ns:contact-1.0"
-	ObjFinance = "http://www.unitedtld.com/epp/finance-1.0"
-	ExtSecDNS  = "urn:ietf:params:xml:ns:secDNS-1.1"
-	ExtRGP     = "urn:ietf:params:xml:ns:rgp-1.0"
-	ExtLaunch  = "urn:ietf:params:xml:ns:launch-1.0"
-	ExtIDN     = "urn:ietf:params:xml:ns:idn-1.0"
-	ExtCharge  = "http://www.unitedtld.com/epp/charge-1.0"
-	ExtFee05   = "urn:ietf:params:xml:ns:fee-0.5"
-	ExtFee06   = "urn:ietf:params:xml:ns:fee-0.6"
-	ExtFee07   = "urn:ietf:params:xml:ns:fee-0.7"
-	ExtPrice   = "urn:ar:params:xml:ns:price-1.1"
+	ObjDomain     = "urn:ietf:params:xml:ns:domain-1.0"
+	ObjHost       = "urn:ietf:params:xml:ns:host-1.0"
+	ObjContact    = "urn:ietf:params:xml:ns:contact-1.0"
+	ObjFinance    = "http://www.unitedtld.com/epp/finance-1.0"
+	ExtSecDNS     = "urn:ietf:params:xml:ns:secDNS-1.1"
+	ExtRGP        = "urn:ietf:params:xml:ns:rgp-1.0"
+	ExtLaunch     = "urn:ietf:params:xml:ns:launch-1.0"
+	ExtIDN        = "urn:ietf:params:xml:ns:idn-1.0"
+	ExtCharge     = "http://www.unitedtld.com/epp/charge-1.0"
+	ExtFee05      = "urn:ietf:params:xml:ns:fee-0.5"
+	ExtFee06      = "urn:ietf:params:xml:ns:fee-0.6"
+	ExtFee07      = "urn:ietf:params:xml:ns:fee-0.7"
+	ExtPrice      = "urn:ar:params:xml:ns:price-1.1"
+	ExtNeulevel   = "urn:ietf:params:xml:ns:neulevel"
+	ExtNeulevel10 = "urn:ietf:params:xml:ns:neulevel-1.0"
 )
 
 func (c *Conn) readGreeting() error {


### PR DESCRIPTION
This extension is used for premium pricing detection.

It is based on #11 due to the registries that currently use this also require a launch phase.