### PR TITLE
Return pointer-typed value for error

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -97,7 +97,7 @@ func (c *Conn) readResponse(res *response_) error {
 		return err
 	}
 	if res.Result.IsError() {
-		return res.Result
+		return &res.Result
 	}
 	return nil
 }

--- a/result.go
+++ b/result.go
@@ -14,19 +14,19 @@ type Result struct {
 
 // IsError determines whether an EPP status code is an error.
 // https://tools.ietf.org/html/rfc5730#section-3
-func (r Result) IsError() bool {
+func (r *Result) IsError() bool {
 	return r.Code >= 2000
 }
 
 // IsFatal determines whether an EPP status code is a fatal response,
 // and the connection should be closed.
 // https://tools.ietf.org/html/rfc5730#section-3
-func (r Result) IsFatal() bool {
+func (r *Result) IsFatal() bool {
 	return r.Code >= 2500
 }
 
 // Error implements the error interface.
-func (r Result) Error() string {
+func (r *Result) Error() string {
 	return fmt.Sprintf("EPP result code %d: %s", r.Code, r.Message)
 }
 


### PR DESCRIPTION
Go convention seems to be that values implementing the `error` interface are pointers. That's certainly what our code that inspects the returned error was expecting.