### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/greeting.go
+++ b/greeting.go
@@ -28,7 +28,7 @@ type Greeting struct {
 	Extensions []string `xml:"svcMenu>svcExtension>extURI,omitempty"`
 }
 
-// SupportsExtension returns true if the EPP server supports
+// SupportsObject returns true if the EPP server supports
 // the object specified by uri.
 func (g *Greeting) SupportsObject(uri string) bool {
 	for _, v := range g.Objects {


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?