### PR TITLE
Encode XML using separate bytes.Buffer instances

### DIFF
--- a/check.go
+++ b/check.go
@@ -18,27 +18,56 @@ func (c *Conn) CheckDomain(domains ...string) (*DomainCheckResponse, error) {
 //  - "neulevel:unspec": a string of the Key=Value data for the unspec tag
 //  - "launch:phase": a string of the launch phase
 func (c *Conn) CheckDomainExtensions(domains []string, extData map[string]string) (*DomainCheckResponse, error) {
-	err := c.encodeDomainCheck(domains, extData)
+	x, err := encodeDomainCheck(&c.Greeting, domains, extData)
 	if err != nil {
 		return nil, err
 	}
-	return c.processDomainCheck(domains)
+
+	err = c.writeDataUnit(x)
+	if err != nil {
+		return nil, err
+	}
+
+	var res Response
+	err = c.readResponse(&res)
+	if err != nil {
+		return nil, err
+	}
+
+	// The ARI price extension won't return both availability and price data
+	// in the same response, so we have to make a separate request for price
+	if c.Greeting.SupportsExtension(ExtPrice) {
+		x, err = encodePriceCheck(domains)
+		if err != nil {
+			return nil, err
+		}
+		err = c.writeDataUnit(x)
+		if err != nil {
+			return nil, err
+		}
+		var res2 Response
+		err = c.readResponse(&res2)
+		if err != nil {
+			return nil, err
+		}
+		res.DomainCheckResponse.Charges = res2.DomainCheckResponse.Charges
+	}
+
+	return &res.DomainCheckResponse, nil
+
 }
 
-func (c *Conn) encodeDomainCheck(domains []string, extData map[string]string) error {
-	c.buf.Reset()
-	c.buf.WriteString(xmlCommandPrefix)
-	c.buf.WriteString(`<check>`)
-	c.buf.WriteString(`<domain:check xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">`)
+func encodeDomainCheck(greeting *Greeting, domains []string, extData map[string]string) ([]byte, error) {
+	buf := bytes.NewBufferString(xmlCommandPrefix)
+	buf.WriteString(`<check>`)
+	buf.WriteString(`<domain:check xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">`)
 	for _, domain := range domains {
-		c.buf.WriteString(`<domain:name>`)
-		xml.EscapeText(&c.buf, []byte(domain))
-		c.buf.WriteString(`</domain:name>`)
+		buf.WriteString(`<domain:name>`)
+		xml.EscapeText(buf, []byte(domain))
+		buf.WriteString(`</domain:name>`)
 	}
-	c.buf.WriteString(`</domain:check>`)
-	c.buf.WriteString(`</check>`)
-
-	greeting := c.Greeting
+	buf.WriteString(`</domain:check>`)
+	buf.WriteString(`</check>`)
 
 	var feeURN string
 	switch {
@@ -73,44 +102,44 @@ func (c *Conn) encodeDomainCheck(domains []string, extData map[string]string) er
 	hasExtension := feeURN != "" || supportsLaunch || supportsNeulevel || supportsNamestore
 
 	if hasExtension {
-		c.buf.WriteString(`<extension>`)
+		buf.WriteString(`<extension>`)
 	}
 
 	// https://www.verisign.com/assets/epp-sdk/verisign_epp-extension_namestoreext_v01.html
 	if supportsNamestore {
-		c.buf.WriteString(`<namestoreExt:namestoreExt xmlns:namestoreExt="`)
-		c.buf.WriteString(ExtNamestore)
-		c.buf.WriteString(`">`)
-		c.buf.WriteString(`<namestoreExt:subProduct>`)
-		c.buf.WriteString(extData["namestoreExt:subProduct"])
-		c.buf.WriteString(`</namestoreExt:subProduct>`)
-		c.buf.WriteString(`</namestoreExt:namestoreExt>`)
+		buf.WriteString(`<namestoreExt:namestoreExt xmlns:namestoreExt="`)
+		buf.WriteString(ExtNamestore)
+		buf.WriteString(`">`)
+		buf.WriteString(`<namestoreExt:subProduct>`)
+		buf.WriteString(extData["namestoreExt:subProduct"])
+		buf.WriteString(`</namestoreExt:subProduct>`)
+		buf.WriteString(`</namestoreExt:namestoreExt>`)
 	}
 
 	if supportsLaunch {
-		c.buf.WriteString(`<launch:check xmlns:launch="`)
-		c.buf.WriteString(ExtLaunch)
-		c.buf.WriteString(`" type="avail">`)
-		c.buf.WriteString(`<launch:phase>`)
-		c.buf.WriteString(extData["launch:phase"])
-		c.buf.WriteString(`</launch:phase>`)
-		c.buf.WriteString(`</launch:check>`)
+		buf.WriteString(`<launch:check xmlns:launch="`)
+		buf.WriteString(ExtLaunch)
+		buf.WriteString(`" type="avail">`)
+		buf.WriteString(`<launch:phase>`)
+		buf.WriteString(extData["launch:phase"])
+		buf.WriteString(`</launch:phase>`)
+		buf.WriteString(`</launch:check>`)
 	}
 
 	if supportsNeulevel {
-		c.buf.WriteString(`<neulevel:extension xmlns:neulevel="`)
-		c.buf.WriteString(ExtNeulevel10)
-		c.buf.WriteString(`">`)
-		c.buf.WriteString(`<neulevel:unspec>`)
-		c.buf.WriteString(extData["neulevel:unspec"])
-		c.buf.WriteString(`</neulevel:unspec>`)
-		c.buf.WriteString(`</neulevel:extension>`)
+		buf.WriteString(`<neulevel:extension xmlns:neulevel="`)
+		buf.WriteString(ExtNeulevel10)
+		buf.WriteString(`">`)
+		buf.WriteString(`<neulevel:unspec>`)
+		buf.WriteString(extData["neulevel:unspec"])
+		buf.WriteString(`</neulevel:unspec>`)
+		buf.WriteString(`</neulevel:extension>`)
 	}
 
 	if len(feeURN) > 0 {
-		c.buf.WriteString(`<fee:check xmlns:fee="`)
-		c.buf.WriteString(feeURN)
-		c.buf.WriteString(`">`)
+		buf.WriteString(`<fee:check xmlns:fee="`)
+		buf.WriteString(feeURN)
+		buf.WriteString(`">`)
 		feePhase := ""
 		if supportsFeePhase {
 			feePhase = fmt.Sprintf(" phase=%q", extData["fee:phase"])
@@ -118,74 +147,41 @@ func (c *Conn) encodeDomainCheck(domains []string, extData map[string]string) er
 		for _, domain := range domains {
 			switch feeURN {
 			case ExtFee09: // Version 0.9 changes the XML structure
-				c.buf.WriteString(`<fee:object objURI="urn:ietf:params:xml:ns:domain-1.0">`)
-				c.buf.WriteString(`<fee:objID element="name">`)
-				xml.EscapeText(&c.buf, []byte(domain))
-				c.buf.WriteString(`</fee:objID>`)
-				c.buf.WriteString(fmt.Sprintf(`<fee:command%s>create</fee:command>`, feePhase))
-				c.buf.WriteString(`</fee:object>`)
+				buf.WriteString(`<fee:object objURI="urn:ietf:params:xml:ns:domain-1.0">`)
+				buf.WriteString(`<fee:objID element="name">`)
+				xml.EscapeText(buf, []byte(domain))
+				buf.WriteString(`</fee:objID>`)
+				buf.WriteString(fmt.Sprintf(`<fee:command%s>create</fee:command>`, feePhase))
+				buf.WriteString(`</fee:object>`)
 			case ExtFee11: // https://tools.ietf.org/html/draft-brown-epp-fees-07#section-5.1.1
-				c.buf.WriteString(fmt.Sprintf(`<fee:command%s>create</fee:command>`, feePhase))
+				buf.WriteString(fmt.Sprintf(`<fee:command%s>create</fee:command>`, feePhase))
 			case ExtFee21: // Version 0.21 changes the XML structure
-				c.buf.WriteString(`<fee:command name="create"/>`)
+				buf.WriteString(`<fee:command name="create"/>`)
 			case ExtFee10:
-				c.buf.WriteString(`<fee:command name="create"/>`)
+				buf.WriteString(`<fee:command name="create"/>`)
 			default:
-				c.buf.WriteString(`<fee:domain>`)
-				c.buf.WriteString(`<fee:name>`)
-				xml.EscapeText(&c.buf, []byte(domain))
-				c.buf.WriteString(`</fee:name>`)
-				c.buf.WriteString(fmt.Sprintf(`<fee:command%s>create</fee:command>`, feePhase))
-				c.buf.WriteString(`</fee:domain>`)
+				buf.WriteString(`<fee:domain>`)
+				buf.WriteString(`<fee:name>`)
+				xml.EscapeText(buf, []byte(domain))
+				buf.WriteString(`</fee:name>`)
+				buf.WriteString(fmt.Sprintf(`<fee:command%s>create</fee:command>`, feePhase))
+				buf.WriteString(`</fee:domain>`)
 			}
 		}
-		c.buf.WriteString(`</fee:check>`)
+		buf.WriteString(`</fee:check>`)
 	}
 
 	if hasExtension {
-		c.buf.WriteString(`</extension>`)
+		buf.WriteString(`</extension>`)
 	}
 
-	c.buf.WriteString(xmlCommandSuffix)
-	return nil
+	buf.WriteString(xmlCommandSuffix)
+
+	return buf.Bytes(), nil
 }
 
-func (c *Conn) processDomainCheck(domains []string) (*DomainCheckResponse, error) {
-	err := c.flushDataUnit()
-	if err != nil {
-		return nil, err
-	}
-	var res Response
-	err = c.readResponse(&res)
-	if err != nil {
-		return nil, err
-	}
-
-	// The ARI price extension won't return both availability and price data
-	// in the same response, so we have to make a separate request for price
-	if c.Greeting.SupportsExtension(ExtPrice) {
-		err := encodePriceCheck(&c.buf, domains)
-		if err != nil {
-			return nil, err
-		}
-		err = c.flushDataUnit()
-		if err != nil {
-			return nil, err
-		}
-		var res2 Response
-		err = c.readResponse(&res2)
-		if err != nil {
-			return nil, err
-		}
-		res.DomainCheckResponse.Charges = res2.DomainCheckResponse.Charges
-	}
-
-	return &res.DomainCheckResponse, nil
-}
-
-func encodePriceCheck(buf *bytes.Buffer, domains []string) error {
-	buf.Reset()
-	buf.WriteString(xmlCommandPrefix)
+func encodePriceCheck(domains []string) ([]byte, error) {
+	buf := bytes.NewBufferString(xmlCommandPrefix)
 	buf.WriteString(`<check>`)
 	buf.WriteString(`<domain:check xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">`)
 	for _, domain := range domains {
@@ -195,15 +191,13 @@ func encodePriceCheck(buf *bytes.Buffer, domains []string) error {
 	}
 	buf.WriteString(`</domain:check>`)
 	buf.WriteString(`</check>`)
-
 	// Extensions
 	buf.WriteString(`<extension>`)
 	// ARI price extension
 	buf.WriteString(`<price:check xmlns:price="urn:ar:params:xml:ns:price-1.1"></price:check>`)
 	buf.WriteString(`</extension>`)
-
 	buf.WriteString(xmlCommandSuffix)
-	return nil
+	return buf.Bytes(), nil
 }
 
 // DomainCheckResponse represents an EPP <response> for a domain check.

--- a/check.go
+++ b/check.go
@@ -11,11 +11,7 @@ import (
 
 // CheckDomain queries the EPP server for the availability status of one or more domains.
 func (c *Conn) CheckDomain(domains ...string) (*DomainCheckResponse, error) {
-	err := c.encodeDomainCheck(domains, nil)
-	if err != nil {
-		return nil, err
-	}
-	return c.processDomainCheck(domains)
+	return c.CheckDomainExtensions(domains, nil)
 }
 
 // CheckDomainExtensions allows specifying extension data for the following:

--- a/check_test.go
+++ b/check_test.go
@@ -37,37 +37,36 @@ func TestConnCheck(t *testing.T) {
 }
 
 func TestEncodeDomainCheck(t *testing.T) {
-	con := &Conn{}
-	err := con.encodeDomainCheck([]string{"hello.com", "foo.domains", "xn--ninja.net"}, nil)
+	x, err := encodeDomainCheck(nil, []string{"hello.com", "foo.domains", "xn--ninja.net"}, nil)
 	st.Expect(t, err, nil)
-	st.Expect(t, con.buf.String(), `<?xml version="1.0" encoding="UTF-8"?>
+	st.Expect(t, string(x), `<?xml version="1.0" encoding="UTF-8"?>
 <epp xmlns="urn:ietf:params:xml:ns:epp-1.0"><command><check><domain:check xmlns:domain="urn:ietf:params:xml:ns:domain-1.0"><domain:name>hello.com</domain:name><domain:name>foo.domains</domain:name><domain:name>xn--ninja.net</domain:name></domain:check></check></command></epp>`)
 	var v struct{}
-	err = xml.Unmarshal(con.buf.Bytes(), &v)
+	err = xml.Unmarshal(x, &v)
 	st.Expect(t, err, nil)
 }
 
 func TestEncodeDomainCheckLaunchPhase(t *testing.T) {
-	con := &Conn{}
-	con.Greeting.Extensions = []string{ExtLaunch}
-	err := con.encodeDomainCheck([]string{"hello.com", "foo.domains", "xn--ninja.net"}, map[string]string{"launch:phase": "claims"})
+	var greeting Greeting
+	greeting.Extensions = []string{ExtLaunch}
+	x, err := encodeDomainCheck(&greeting, []string{"hello.com", "foo.domains", "xn--ninja.net"}, map[string]string{"launch:phase": "claims"})
 	st.Expect(t, err, nil)
-	st.Expect(t, con.buf.String(), `<?xml version="1.0" encoding="UTF-8"?>
+	st.Expect(t, string(x), `<?xml version="1.0" encoding="UTF-8"?>
 <epp xmlns="urn:ietf:params:xml:ns:epp-1.0"><command><check><domain:check xmlns:domain="urn:ietf:params:xml:ns:domain-1.0"><domain:name>hello.com</domain:name><domain:name>foo.domains</domain:name><domain:name>xn--ninja.net</domain:name></domain:check></check><extension><launch:check xmlns:launch="urn:ietf:params:xml:ns:launch-1.0" type="avail"><launch:phase>claims</launch:phase></launch:check></extension></command></epp>`)
 	var v struct{}
-	err = xml.Unmarshal(con.buf.Bytes(), &v)
+	err = xml.Unmarshal(x, &v)
 	st.Expect(t, err, nil)
 }
 
 func TestEncodeDomainCheckNeulevelUnspec(t *testing.T) {
-	con := &Conn{}
-	con.Greeting.Extensions = []string{ExtNeulevel}
-	err := con.encodeDomainCheck([]string{"hello.com", "foo.domains", "xn--ninja.net"}, map[string]string{"neulevel:unspec": "FeeCheck=Y"})
+	var greeting Greeting
+	greeting.Extensions = []string{ExtNeulevel}
+	x, err := encodeDomainCheck(&greeting, []string{"hello.com", "foo.domains", "xn--ninja.net"}, map[string]string{"neulevel:unspec": "FeeCheck=Y"})
 	st.Expect(t, err, nil)
-	st.Expect(t, con.buf.String(), `<?xml version="1.0" encoding="UTF-8"?>
+	st.Expect(t, string(x), `<?xml version="1.0" encoding="UTF-8"?>
 <epp xmlns="urn:ietf:params:xml:ns:epp-1.0"><command><check><domain:check xmlns:domain="urn:ietf:params:xml:ns:domain-1.0"><domain:name>hello.com</domain:name><domain:name>foo.domains</domain:name><domain:name>xn--ninja.net</domain:name></domain:check></check><extension><neulevel:extension xmlns:neulevel="urn:ietf:params:xml:ns:neulevel-1.0"><neulevel:unspec>FeeCheck=Y</neulevel:unspec></neulevel:extension></extension></command></epp>`)
 	var v struct{}
-	err = xml.Unmarshal(con.buf.Bytes(), &v)
+	err = xml.Unmarshal(x, &v)
 	st.Expect(t, err, nil)
 }
 
@@ -755,10 +754,9 @@ func TestScanCheckDomainResponsePriceExtension(t *testing.T) {
 }
 
 func BenchmarkEncodeDomainCheck(b *testing.B) {
-	con := &Conn{}
 	domains := []string{"hello.com"}
 	for i := 0; i < b.N; i++ {
-		con.encodeDomainCheck(domains, nil)
+		encodeDomainCheck(nil, domains, nil)
 	}
 }
 

--- a/conn.go
+++ b/conn.go
@@ -86,11 +86,6 @@ func (c *Conn) reset() {
 	*c.decoder = c.saved // Heh.
 }
 
-// flushDataUnit writes bytes from c.buf to c using writeDataUnit.
-func (c *Conn) flushDataUnit() error {
-	return c.writeDataUnit(c.buf.Bytes())
-}
-
 // writeDataUnit writes a slice of bytes to c.
 // Bytes written are prefixed with 32-bit header specifying the total size
 // of the data unit (message + 4 byte header), in network (big-endian) order.

--- a/greeting.go
+++ b/greeting.go
@@ -31,6 +31,9 @@ type Greeting struct {
 // SupportsObject returns true if the EPP server supports
 // the object specified by uri.
 func (g *Greeting) SupportsObject(uri string) bool {
+	if g == nil {
+		return false
+	}
 	for _, v := range g.Objects {
 		if v == uri {
 			return true
@@ -42,6 +45,9 @@ func (g *Greeting) SupportsObject(uri string) bool {
 // SupportsExtension returns true if the EPP server supports
 // the extension specified by uri.
 func (g *Greeting) SupportsExtension(uri string) bool {
+	if g == nil {
+		return false
+	}
 	for _, v := range g.Extensions {
 		if v == uri {
 			return true

--- a/session.go
+++ b/session.go
@@ -29,16 +29,15 @@ func (c *Conn) writeLogin(user, password, newPassword string) error {
 	if len(c.Greeting.Languages) > 0 {
 		lang = c.Greeting.Languages[0]
 	}
-	err := encodeLogin(&c.buf, user, password, newPassword, ver, lang, c.Greeting.Objects, c.Greeting.Extensions)
+	x, err := encodeLogin(user, password, newPassword, ver, lang, c.Greeting.Objects, c.Greeting.Extensions)
 	if err != nil {
 		return err
 	}
-	return c.flushDataUnit()
+	return c.writeDataUnit(x)
 }
 
-func encodeLogin(buf *bytes.Buffer, user, password, newPassword, version, language string, objects, extensions []string) error {
-	buf.Reset()
-	buf.WriteString(xmlCommandPrefix)
+func encodeLogin(user, password, newPassword, version, language string, objects, extensions []string) ([]byte, error) {
+	buf := bytes.NewBufferString(xmlCommandPrefix)
 	buf.WriteString(`<login><clID>`)
 	xml.EscapeText(buf, []byte(user))
 	buf.WriteString(`</clID><pw>`)
@@ -70,7 +69,7 @@ func encodeLogin(buf *bytes.Buffer, user, password, newPassword, version, langua
 	}
 	buf.WriteString(`</svcs></login>`)
 	buf.WriteString(xmlCommandSuffix)
-	return nil
+	return buf.Bytes(), nil
 }
 
 // Logout sends a <logout> command to terminate an EPP session.

--- a/session_test.go
+++ b/session_test.go
@@ -1,7 +1,6 @@
 package epp
 
 import (
-	"bytes"
 	"encoding/xml"
 	"testing"
 
@@ -9,24 +8,22 @@ import (
 )
 
 func TestEncodeLogin(t *testing.T) {
-	var buf bytes.Buffer
-	err := encodeLogin(&buf, "jane", "battery", "", "1.0", "en", nil, nil)
+	x, err := encodeLogin("jane", "battery", "", "1.0", "en", nil, nil)
 	st.Expect(t, err, nil)
-	st.Expect(t, buf.String(), `<?xml version="1.0" encoding="UTF-8"?>
+	st.Expect(t, string(x), `<?xml version="1.0" encoding="UTF-8"?>
 <epp xmlns="urn:ietf:params:xml:ns:epp-1.0"><command><login><clID>jane</clID><pw>battery</pw><options><version>1.0</version><lang>en</lang></options><svcs></svcs></login></command></epp>`)
 	var v struct{}
-	err = xml.Unmarshal(buf.Bytes(), &v)
+	err = xml.Unmarshal(x, &v)
 	st.Expect(t, err, nil)
 }
 
 func TestEncodeLoginChangePassword(t *testing.T) {
-	var buf bytes.Buffer
-	err := encodeLogin(&buf, "jane", "battery", "horse", "1.0", "en", nil, nil)
+	x, err := encodeLogin("jane", "battery", "horse", "1.0", "en", nil, nil)
 	st.Expect(t, err, nil)
-	st.Expect(t, buf.String(), `<?xml version="1.0" encoding="UTF-8"?>
+	st.Expect(t, string(x), `<?xml version="1.0" encoding="UTF-8"?>
 <epp xmlns="urn:ietf:params:xml:ns:epp-1.0"><command><login><clID>jane</clID><pw>battery</pw><newPW>horse</newPW><options><version>1.0</version><lang>en</lang></options><svcs></svcs></login></command></epp>`)
 	var v struct{}
-	err = xml.Unmarshal(buf.Bytes(), &v)
+	err = xml.Unmarshal(x, &v)
 	st.Expect(t, err, nil)
 }
 
@@ -49,8 +46,7 @@ var (
 )
 
 func BenchmarkEncodeLogin(b *testing.B) {
-	var buf bytes.Buffer
 	for i := 0; i < b.N; i++ {
-		encodeLogin(&buf, "jane", "battery", "horse", "1.0", "en", testObjects, testExtensions)
+		encodeLogin("jane", "battery", "horse", "1.0", "en", testObjects, testExtensions)
 	}
 }


### PR DESCRIPTION
- CheckDomain now just calls CheckDomainExtensions(..., nil)
- Encode EPP requests to new, distinct bytes.Buffer instances

This will allow XML encoding to be parallelized for a given EPP connection. A future commit or PR will make this same change for XML decoding. The eventual goal is to implement support for EPP command pipelining using the <clTRID> element.

The Go GC has improved substantially since this (somewhat defensive) code was written.