### PR TITLE
Support concurrent access via mutex and worker goroutine

### DIFF
--- a/check.go
+++ b/check.go
@@ -23,13 +23,12 @@ func (c *Conn) CheckDomainExtensions(domains []string, extData map[string]string
 		return nil, err
 	}
 
-	err = c.writeDataUnit(x)
+	err = c.writeRequest(x)
 	if err != nil {
 		return nil, err
 	}
 
-	var res Response
-	err = c.readResponse(&res)
+	res, err := c.readResponse()
 	if err != nil {
 		return nil, err
 	}
@@ -41,12 +40,11 @@ func (c *Conn) CheckDomainExtensions(domains []string, extData map[string]string
 		if err != nil {
 			return nil, err
 		}
-		err = c.writeDataUnit(x)
+		err = c.writeRequest(x)
 		if err != nil {
 			return nil, err
 		}
-		var res2 Response
-		err = c.readResponse(&res2)
+		res2, err := c.readResponse()
 		if err != nil {
 			return nil, err
 		}

--- a/conn.go
+++ b/conn.go
@@ -1,7 +1,6 @@
 package epp
 
 import (
-	"bytes"
 	"encoding/binary"
 	"encoding/xml"
 	"io"
@@ -181,24 +180,4 @@ func parseDataUnit(r io.Reader) (int32, error) {
 		return 0, io.ErrUnexpectedEOF
 	}
 	return n, err
-}
-
-func deleteRange(s, pfx, sfx []byte) []byte {
-	start := bytes.Index(s, pfx)
-	if start < 0 {
-		return s
-	}
-	end := bytes.Index(s[start+len(pfx):], sfx)
-	if end < 0 {
-		return s
-	}
-	end += start + len(pfx) + len(sfx)
-	size := len(s) - (end - start)
-	copy(s[start:size], s[end:])
-	return s[:size]
-}
-
-func deleteBufferRange(buf *bytes.Buffer, pfx, sfx []byte) {
-	v := deleteRange(buf.Bytes(), pfx, sfx)
-	buf.Truncate(len(v))
 }

--- a/conn.go
+++ b/conn.go
@@ -68,7 +68,9 @@ func NewTimeoutConn(conn net.Conn, timeout time.Duration) (*Conn, error) {
 	c.Timeout = timeout
 	g, err := c.readGreeting()
 	if err == nil {
+		c.m.Lock()
 		c.Greeting = g
+		c.m.Unlock()
 	}
 	return c, err
 }

--- a/conn.go
+++ b/conn.go
@@ -137,7 +137,7 @@ func (c *Conn) readLoop() {
 		if timeout > 0 {
 			c.Conn.SetReadDeadline(time.Now().Add(timeout))
 		}
-		n, err := parseDataUnit(c.Conn)
+		n, err := readDataUnitHeader(c.Conn)
 		if err != nil {
 			c.readErr = err
 			return
@@ -168,11 +168,11 @@ func writeDataUnit(w io.Writer, x []byte) error {
 	return err
 }
 
-// parseDataUnit reads a single EPP data unit header from r, returning the payload size or an error.
+// readDataUnitHeader reads a single EPP data unit header from r, returning the payload size or an error.
 // An EPP data unit is prefixed with 32-bit header specifying the total size
 // of the data unit (message + 4 byte header), in network (big-endian) order.
 // http://www.ietf.org/rfc/rfc4934.txt
-func parseDataUnit(r io.Reader) (uint32, error) {
+func readDataUnitHeader(r io.Reader) (uint32, error) {
 	var n uint32
 	err := binary.Read(r, binary.BigEndian, &n)
 	if err != nil {

--- a/conn.go
+++ b/conn.go
@@ -172,8 +172,8 @@ func writeDataUnit(w io.Writer, x []byte) error {
 // An EPP data unit is prefixed with 32-bit header specifying the total size
 // of the data unit (message + 4 byte header), in network (big-endian) order.
 // http://www.ietf.org/rfc/rfc4934.txt
-func parseDataUnit(r io.Reader) (int32, error) {
-	var n int32
+func parseDataUnit(r io.Reader) (uint32, error) {
+	var n uint32
 	err := binary.Read(r, binary.BigEndian, &n)
 	if err != nil {
 		return 0, err

--- a/conn.go
+++ b/conn.go
@@ -178,9 +178,9 @@ func parseDataUnit(r io.Reader) (uint32, error) {
 	if err != nil {
 		return 0, err
 	}
-	n -= 4 // https://tools.ietf.org/html/rfc5734#section-4
-	if n < 0 {
+	if n < 4 {
 		return 0, io.ErrUnexpectedEOF
 	}
-	return n, err
+	// https://tools.ietf.org/html/rfc5734#section-4
+	return n - 4, err
 }

--- a/conn.go
+++ b/conn.go
@@ -43,12 +43,7 @@ type Conn struct {
 // handshake. It reads and stores the initial EPP <greeting> message.
 // https://tools.ietf.org/html/rfc5730#section-2.4
 func NewConn(conn net.Conn) (*Conn, error) {
-	c := newConn(conn)
-	g, err := c.readGreeting()
-	if err == nil {
-		c.Greeting = g
-	}
-	return c, err
+	return NewTimeoutConn(conn, 0)
 }
 
 // NewTimeoutConn initializes an epp.Conn like NewConn, limiting the duration of network

--- a/conn.go
+++ b/conn.go
@@ -169,7 +169,7 @@ func writeDataUnit(w io.Writer, x []byte) error {
 }
 
 // parseDataUnit reads a single EPP data unit header from r, returning the payload size or an error.
-// An EPP data units is prefixed with 32-bit header specifying the total size
+// An EPP data unit is prefixed with 32-bit header specifying the total size
 // of the data unit (message + 4 byte header), in network (big-endian) order.
 // http://www.ietf.org/rfc/rfc4934.txt
 func parseDataUnit(r io.Reader) (int32, error) {

--- a/conn_test.go
+++ b/conn_test.go
@@ -1,6 +1,7 @@
 package epp
 
 import (
+	"bytes"
 	"net"
 	"sync"
 	"testing"
@@ -73,4 +74,24 @@ func TestDeleteRange(t *testing.T) {
 
 	v = deleteRange([]byte(`<foo><bar><baz></baz></bar></foo>`), []byte(`</bar>`), []byte(`o>`))
 	st.Expect(t, string(v), `<foo><bar><baz></baz>`)
+}
+
+func deleteBufferRange(buf *bytes.Buffer, pfx, sfx []byte) {
+	v := deleteRange(buf.Bytes(), pfx, sfx)
+	buf.Truncate(len(v))
+}
+
+func deleteRange(s, pfx, sfx []byte) []byte {
+	start := bytes.Index(s, pfx)
+	if start < 0 {
+		return s
+	}
+	end := bytes.Index(s[start+len(pfx):], sfx)
+	if end < 0 {
+		return s
+	}
+	end += start + len(pfx) + len(sfx)
+	size := len(s) - (end - start)
+	copy(s[start:size], s[end:])
+	return s[:size]
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -52,7 +52,7 @@ func TestNewConn(t *testing.T) {
 		err = writeDataUnit(conn, []byte(testXMLGreeting))
 		st.Assert(t, err, nil)
 		// Read logout message
-		_, err = parseDataUnit(conn)
+		_, err = readDataUnitHeader(conn)
 		st.Assert(t, err, nil)
 		// Close connection
 		err = conn.Close()

--- a/conn_test.go
+++ b/conn_test.go
@@ -1,7 +1,6 @@
 package epp
 
 import (
-	"bytes"
 	"net"
 	"sync"
 	"testing"
@@ -52,8 +51,7 @@ func TestNewConn(t *testing.T) {
 		err = writeDataUnit(conn, []byte(testXMLGreeting))
 		st.Assert(t, err, nil)
 		// Read logout message
-		buf := &bytes.Buffer{}
-		err = readDataUnit(buf, conn)
+		_, err = parseDataUnit(conn)
 		st.Assert(t, err, nil)
 		// Close connection
 		err = conn.Close()

--- a/greeting.go
+++ b/greeting.go
@@ -8,7 +8,7 @@ import (
 
 // Hello sends a <hello> command to request a <greeting> from the EPP server.
 func (c *Conn) Hello() error {
-	err := c.writeDataUnit(xmlHello)
+	err := c.writeRequest(xmlHello)
 	if err != nil {
 		return err
 	}
@@ -102,14 +102,9 @@ var ExtURNNames = map[string]string{
 	"neulevel-1.0":     ExtNeulevel10,
 }
 
+// TODO: check if res.Greeting is not empty.
 func (c *Conn) readGreeting() (Greeting, error) {
-	err := c.readDataUnit()
-	if err != nil {
-		return Greeting{}, err
-	}
-	deleteBufferRange(&c.buf, []byte(`<dcp>`), []byte(`</dcp>`))
-	var res Response
-	err = IgnoreEOF(scanResponse.Scan(c.decoder, &res))
+	res, err := c.readResponse()
 	if err != nil {
 		return Greeting{}, err
 	}

--- a/greeting_test.go
+++ b/greeting_test.go
@@ -16,12 +16,11 @@ func TestHello(t *testing.T) {
 	ls.buildup(func(ls *localServer, ln net.Listener) {
 		conn, err := ls.Accept()
 		st.Assert(t, err, nil)
-		sc := newConn(conn)
 		// Respond with greeting
-		err = sc.writeDataUnit([]byte(testXMLGreeting))
+		err = writeDataUnit(conn, []byte(testXMLGreeting))
 		st.Assert(t, err, nil)
 		// Respond with greeting for <hello>
-		err = sc.writeDataUnit([]byte(testXMLGreeting))
+		err = writeDataUnit(conn, []byte(testXMLGreeting))
 		st.Assert(t, err, nil)
 	})
 	nc, err := net.Dial(ls.Listener.Addr().Network(), ls.Listener.Addr().String())

--- a/info.go
+++ b/info.go
@@ -15,12 +15,11 @@ func (c *Conn) DomainInfo(domain string, extData map[string]string) (*DomainInfo
 	if err != nil {
 		return nil, err
 	}
-	err = c.writeDataUnit(x)
+	err = c.writeRequest(x)
 	if err != nil {
 		return nil, err
 	}
-	var res Response
-	err = c.readResponse(&res)
+	res, err := c.readResponse()
 	if err != nil {
 		return nil, err
 	}

--- a/session.go
+++ b/session.go
@@ -19,7 +19,9 @@ func (c *Conn) Login(user, password, newPassword string) error {
 	// We always have a .Result in our non-pointer, but it might be meaningless.
 	// We might not have read anything.  We think that the worst case is we
 	// have the same zero values we'd get without the assignment-even-in-error-case.
+	c.m.Lock()
 	c.LoginResult = res.Result
+	c.m.Unlock()
 	return err
 }
 

--- a/session.go
+++ b/session.go
@@ -12,8 +12,10 @@ func (c *Conn) Login(user, password, newPassword string) error {
 	if err != nil {
 		return err
 	}
-	var res Response
-	err = c.readResponse(&res)
+	res, err := c.readResponse()
+	if err != nil {
+		return nil
+	}
 	// We always have a .Result in our non-pointer, but it might be meaningless.
 	// We might not have read anything.  We think that the worst case is we
 	// have the same zero values we'd get without the assignment-even-in-error-case.
@@ -33,7 +35,7 @@ func (c *Conn) writeLogin(user, password, newPassword string) error {
 	if err != nil {
 		return err
 	}
-	return c.writeDataUnit(x)
+	return c.writeRequest(x)
 }
 
 func encodeLogin(user, password, newPassword, version, language string, objects, extensions []string) ([]byte, error) {
@@ -75,12 +77,12 @@ func encodeLogin(user, password, newPassword, version, language string, objects,
 // Logout sends a <logout> command to terminate an EPP session.
 // https://tools.ietf.org/html/rfc5730#section-2.9.1.2
 func (c *Conn) Logout() error {
-	err := c.writeDataUnit(xmlLogout)
+	err := c.writeRequest(xmlLogout)
 	if err != nil {
 		return err
 	}
-	var res Response
-	return c.readResponse(&res)
+	_, err = c.readResponse()
+	return err
 }
 
 var xmlLogout = []byte(xmlCommandPrefix + `<logout/>` + xmlCommandSuffix)


### PR DESCRIPTION
This is step 2 to enabling EPP command pipelining.

- Eliminates the hack where it would reset an `xml.Decoder` by assigning it to a saved state
- CheckDomain now just calls CheckDomainExtensions(..., nil)
- Encode EPP requests to new, distinct bytes.Buffer instances
- remove (*Conn).flushDataUnit method
- NewConn now just calls NewTimeoutConn(..., 0)
- Serialize reads and writes to the underlying connection
- Add mutex around Conn.Greeting and .LoginResult
