### PR TITLE
Extract EPP Result error in readResponse

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -117,6 +117,12 @@ func (c *Conn) readResponse() (*Response, error) {
 	r := io.LimitedReader{R: c.Conn, N: int64(n)}
 	res := &Response{}
 	err = IgnoreEOF(scanResponse.Scan(xml.NewDecoder(&r), res))
+	if err != nil {
+		return res, err
+	}
+	if res.Result.IsError() {
+		return res, &res.Result
+	}
 	return res, err
 }
 


### PR DESCRIPTION
Reintroduces error check lost in b463fd18dcf4d3a21226a7ea622921f7271cc7b2.